### PR TITLE
Prettier time

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
       }
 
       body {
+        font-size: 1rem;
+        line-height: 1.525rem;
+
+        color: #fff;
+
         background-color: transparent;
         background-size: cover;
         background-position: center center;
@@ -43,16 +48,16 @@
 
       .PrettyNewTab-time {
         position: absolute;
-        color: white;
-        font-size: 1.5em;
-        font-family: "Lucida Grande", "Lucida Sans Unicode", Helvetica, Arial, sans-serif;
-        padding: 1em;
-        line-height: 1em;
-        letter-spacing: 0.05em;
-        cursor: default;
-        text-shadow: 0 0 5px black;
         top: 0;
         right: 0;
+
+        padding: 1rem;
+
+        font-family: "Helvetica Neue", Helvetica, "Lucida Grande", "Lucida Sans Unicode", Arial, sans-serif;
+        font-size: 1.5rem;
+        font-weight: 200;
+
+        text-shadow: 0 0 0.2rem rgba(0,0,0,.8);
       }
     </style>
   </head>


### PR DESCRIPTION
Before

![before](http://cl.ly/image/2T0n2x3E031X/Screen%20Shot%202014-10-01%20at%2020.04.37.png)

After

![before](http://cl.ly/image/3w193x2o0r2O/Screen%20Shot%202014-10-01%20at%2020.05.01.png)

Note: render on Firefox OS X
